### PR TITLE
refactor(DataList): renombré métodos

### DIFF
--- a/addons/mod_manager/src/data/data_list.gd
+++ b/addons/mod_manager/src/data/data_list.gd
@@ -36,42 +36,85 @@ func get_data_nodes() -> Array[Data]:
 ## Agrega [param data] a la lista y luego regresa el mismo nodo. Si [param only_one] es
 ## [code]true[/code] se comprobará si ya existe algún nodo con la misma scene_file_path, si existe
 ## no se agregará y se regresará el ya nodo existente.
+## @deprecated
 func add_data(data: Data, only_one: bool = false) -> Data:
-	data.set_unique(false)
+	push_warning("This method has been deprecated, use add_data_node instead.")
+	return add_data_node(data, only_one)
+
+
+## Agrega [param data_node] a la lista y luego regresa el mismo nodo. Si [param only_one] es
+## [code]true[/code] se comprobará si ya existe algún nodo con la misma scene_file_path, si existe
+## no se agregará y se regresará el ya nodo existente.
+func add_data_node(data_node: Data, only_one: bool = false) -> Data:
+	data_node.set_unique(false)
 	var force_readable_name: bool = true
 
 	if only_one:
-		if data.scene_file_path.is_empty():
-			push_error("%s no es una escena. No se pudo agregar a %s" % [data.name, name])
+		if data_node.scene_file_path.is_empty():
+			push_error("%s no es una escena. No se pudo agregar a %s" % [data_node.name, name])
 			return null
 
 		for node: Node in get_data_nodes():
 			var path: String = node.scene_file_path
 			if path.is_empty():
 				continue
-			elif path == data.scene_file_path:
+			elif path == data_node.scene_file_path:
+				if not data_node.is_unique():
+					data_node.delete()
 				return node
 
-	add_child(data, force_readable_name)
+	add_child(data_node, force_readable_name)
 
-	return data
+	return data_node
 
 
 ## Obtiene un nodo [Data] por su identificador.[br]
 ## [param id]: nombre del nodo.
+## @deprecated
 func get_data_by_name(id: String) -> Data:
+	push_warning("This method has been deprecated, use get_data_node_by_name instead.")
+	return get_data_node_by_name(id)
+
+
+## Obtiene un nodo [Data] por su identificador.[br]
+## [param id]: nombre del nodo.
+func get_data_node_by_name(id: String) -> Data:
+	if id.is_empty():
+		return null
 	return get_node_or_null(id)
 
 
 ## Regresa [code]true[/code] si [param data] se encuentra en la lista.
+## @deprecated
 func has_data(data: Data) -> bool:
-	return data in get_children()
+	push_warning("This method has been deprecated, use has_data_node instead.")
+	return has_data_node(data)
+
+
+## Regresa [code]true[/code] si [param data_node] se encuentra en la lista.
+func has_data_node(data_node: Data) -> bool:
+	return data_node in get_children()
 
 
 ## Quita nodo [param data] de la lista. Si [param destroy] es [code]true[/code]
 ## Quita el nodo y lo borra.
 func remove_data(data: Data, destroy: bool = false) -> void:
-	if has_data(data):
-		remove_child(data)
+	push_warning("This method has been deprecated, use remove_data_node instead.")
+	remove_data_node(data, destroy)
+
+
+## Quita nodo [param data_node] de la lista. Si [param destroy] es [code]true[/code]
+## Quita el nodo y lo borra.
+func remove_data_node(data_node: Data, destroy: bool = false) -> void:
+	if has_data(data_node):
+		remove_child(data_node)
 		if destroy:
-			data.delete()
+			data_node.delete()
+
+
+## Quita nodo con nombre [param data_node_name] de la lista. Si [param destroy] es
+## [code]true[/code] Quita el nodo y lo borra.
+func remove_data_node_by_name(data_node_name: String, destroy: bool = false) -> void:
+	var data_node: Data = get_data_by_name(data_node_name)
+	if data_node != null:
+		remove_data_node(data_node)

--- a/addons/mod_manager/test/data/data_list_test.gd
+++ b/addons/mod_manager/test/data/data_list_test.gd
@@ -13,69 +13,79 @@ func test_get_data_nodes() -> void:
 	var data_list: DataList = auto_free(DataList.new()) as DataList
 	var data_0: Data = auto_free(Data.new()) as Data
 	var data_1: Data = auto_free(Data.new()) as Data
-	data_list.add_data(data_0)
-	data_list.add_data(data_1)
+	data_list.add_data_node(data_0)
+	data_list.add_data_node(data_1)
 	var datas: Array[Data] = data_list.get_data_nodes()
 	assert_array(datas).contains([data_0, data_1])
 
 
-func test_add_data_only_one_false() -> void:
+func test_add_data_node_only_one_false() -> void:
 	var data_list: DataList = auto_free(DataList.new()) as DataList
 	var data: Data = auto_free(Data.new()) as Data
-	data_list.add_data(data)
+	data_list.add_data_node(data)
 	assert_bool(data.is_unique()).is_false()
-	var result: bool = data_list.has_data(data)
+	var result: bool = data_list.has_data_node(data)
 	assert_bool(result).is_true()
 
 
-func test_add_data_only_one_true_is_not_scene() -> void:
+func test_add_data_node_only_one_true_is_not_scene() -> void:
 	var data_list: DataList = auto_free(DataList.new()) as DataList
 	var only_one: bool = true
-	assert_object(data_list.add_data(auto_free(Data.new()), only_one)).is_null()
+	assert_object(data_list.add_data_node(auto_free(Data.new()), only_one)).is_null()
 
 
-func test_add_data_only_one_true_non_existent_data() -> void:
+func test_add_data_node_only_one_true_non_existent_data() -> void:
 	var data_list: DataList = auto_free(DataList.new()) as DataList
 	var data: Data = auto_free(MY_DATA.instantiate()) as Data
 	var only_one: bool = true
-	assert_object(data_list.add_data(data, only_one)).is_same(data)
-	assert_bool(data_list.has_data(data)).is_true()
+	assert_object(data_list.add_data_node(data, only_one)).is_same(data)
+	assert_bool(data_list.has_data_node(data)).is_true()
 
 
-func test_add_data_only_one_true_existing_data() -> void:
+func test_add_data_node_only_one_true_existing_data() -> void:
 	var data_list: DataList = auto_free(DataList.new()) as DataList
 	var only_one: bool = true
-	var existing_data: Data = data_list.add_data(auto_free(MY_DATA.instantiate()), only_one)
+	var existing_data: Data = data_list.add_data_node(auto_free(MY_DATA.instantiate()), only_one)
 	var data: Data = auto_free(MY_DATA.instantiate()) as Data
-	var added_data: Data = data_list.add_data(data, only_one)
+	var added_data: Data = data_list.add_data_node(data, only_one)
 	assert_object(added_data).is_not_same(data)
 	assert_object(added_data).is_same(existing_data)
-	assert_bool(data_list.has_data(data)).is_false()
+	assert_bool(data_list.has_data_node(data)).is_false()
 
 
-func test_get_data_by_name() -> void:
+func test_get_data_node_by_name() -> void:
 	var data_list: DataList = auto_free(DataList.new()) as DataList
 	var _name: String = "nombre"
 	var data: Data = auto_free(Data.new()) as Data
 	data.name = _name
-	data_list.add_data(data)
-	var result: Data = data_list.get_data_by_name(_name)
+	data_list.add_data_node(data)
+	var result: Data = data_list.get_data_node_by_name(_name)
 	assert_object(result).is_same(data)
 
 
 func test_has_data_node() -> void:
 	var data_list: DataList = auto_free(DataList.new()) as DataList
 	var data: Data = auto_free(Data.new()) as Data
-	data_list.add_data(data)
-	var result: bool = data_list.has_data(data)
+	data_list.add_data_node(data)
+	var result: bool = data_list.has_data_node(data)
 	assert_bool(result).is_true()
 
 
-func test_remove_data() -> void:
+func test_remove_data_node() -> void:
 	var data_list: DataList = auto_free(DataList.new()) as DataList
 	var data: Data = Data.new()
-	data_list.add_data(data)
+	data_list.add_data_node(data)
 	var destroy: bool = true
-	data_list.remove_data(data, destroy)
-	var result: bool = data_list.has_data(data)
+	data_list.remove_data_node(data, destroy)
+	var result: bool = data_list.has_data_node(data)
+	assert_bool(result).is_false()
+
+
+func test_remove_data_node_by_name() -> void:
+	var data_list: DataList = auto_free(DataList.new()) as DataList
+	var data: Data = auto_free(Data.new())
+	data_list.add_data_node(data)
+	var destroy: bool = true
+	data_list.remove_data_node_by_name(data.name, destroy)
+	var result: bool = data_list.has_data_node(data)
 	assert_bool(result).is_false()


### PR DESCRIPTION
## Description
Renombre métodos de la clase DataList.
Método add_data pasa a llamarse add_data_node.
Método get_data_by_name pasa a llamarse get_data_node_by_name.
Método has_data pasa a llamarse has_data_node.
Método remove_data pasa a llamarse remove_data_node.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update

## Checklist
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
